### PR TITLE
Add configurable iPadOS keyboard and Stage Manager modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ TrollPadSB_LIBRARIES = MobileGestalt
 
 TrollPadUI_FILES = TweakUI.x
 TrollPadUI_CFLAGS = -fobjc-arc
-TrollPadUI_LIBRARIES = root
 
 include $(THEOS_MAKE_PATH)/tweak.mk
 SUBPROJECTS += TrollPadPrefs

--- a/TPPrefsObserver.h
+++ b/TPPrefsObserver.h
@@ -2,5 +2,5 @@
 
 @interface TPPrefsObserver : NSObject
 @property(nonatomic, assign) BOOL allowLandscapeHomeScreen, forceEnableMedusaForLandscapeOnlyApps, hideStageManagerResizeCorners, useiPadAppSwitchingAnimation, isFloatingDockSupported, scaleGridSwitcher;
-@property(nonatomic, assign) NSInteger multitaskingMode;
+@property(nonatomic, assign) NSInteger multitaskingMode, stageManagerSide;
 @end

--- a/TPPrefsObserver.h
+++ b/TPPrefsObserver.h
@@ -2,4 +2,5 @@
 
 @interface TPPrefsObserver : NSObject
 @property(nonatomic, assign) BOOL allowLandscapeHomeScreen, forceEnableMedusaForLandscapeOnlyApps, hideStageManagerResizeCorners, useiPadAppSwitchingAnimation, isFloatingDockSupported, scaleGridSwitcher;
+@property(nonatomic, assign) NSInteger multitaskingMode;
 @end

--- a/TPPrefsObserver.m
+++ b/TPPrefsObserver.m
@@ -10,6 +10,7 @@
     [self observeKey:@"TPIsFloatingDockSupported"];
     [self observeKey:@"TPScaleGridSwitcher"];
     [self observeKey:@"TPMultitaskingMode"];
+    [self observeKey:@"TPStageManagerSide"];
     // Fetch keys
     [self observeValueForKeyPath:nil ofObject:nil change:nil context:nil];
     return self;
@@ -32,5 +33,6 @@ keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)contex
     self.isFloatingDockSupported = [defaults boolForKey:@"TPIsFloatingDockSupported"];
     self.scaleGridSwitcher = [defaults boolForKey:@"TPScaleGridSwitcher"];
     self.multitaskingMode = [defaults integerForKey:@"TPMultitaskingMode"];
+    self.stageManagerSide = [defaults integerForKey:@"TPStageManagerSide"];
 }
 @end

--- a/TPPrefsObserver.m
+++ b/TPPrefsObserver.m
@@ -9,6 +9,7 @@
     [self observeKey:@"TPUseiPadAppSwitchingAnimation"];
     [self observeKey:@"TPIsFloatingDockSupported"];
     [self observeKey:@"TPScaleGridSwitcher"];
+    [self observeKey:@"TPMultitaskingMode"];
     // Fetch keys
     [self observeValueForKeyPath:nil ofObject:nil change:nil context:nil];
     return self;
@@ -30,5 +31,6 @@ keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)contex
     self.useiPadAppSwitchingAnimation = [defaults boolForKey:@"TPUseiPadAppSwitchingAnimation"];
     self.isFloatingDockSupported = [defaults boolForKey:@"TPIsFloatingDockSupported"];
     self.scaleGridSwitcher = [defaults boolForKey:@"TPScaleGridSwitcher"];
+    self.multitaskingMode = [defaults integerForKey:@"TPMultitaskingMode"];
 }
 @end

--- a/TrollPadPrefs/Resources/Root.plist
+++ b/TrollPadPrefs/Resources/Root.plist
@@ -8,7 +8,7 @@
 			<key>cell</key>
 			<string>PSGroupCell</string>
 			<key>footerText</key>
-			<string>Follow Control Center preserves the current behavior. Stage Manager also unlocks main-display window resizing. Respring after changing modes.</string>
+			<string>Follow Control Center preserves the current behavior. Stage Manager also unlocks main-display window resizing. Respring after changing modes or the Stage Manager side.</string>
 			<key>label</key>
 			<string>Multitasking</string>
 		</dict>
@@ -23,6 +23,8 @@
 			<string>com.apple.springboard</string>
 			<key>key</key>
 			<string>TPMultitaskingMode</string>
+			<key>id</key>
+			<string>MULTITASKING_MODE</string>
 			<key>label</key>
 			<string>Multitasking Mode</string>
 			<key>validTitles</key>
@@ -36,6 +38,32 @@
 				<integer>0</integer>
 				<integer>1</integer>
 				<integer>3</integer>
+			</array>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSLinkListCell</string>
+			<key>default</key>
+			<integer>0</integer>
+			<key>detail</key>
+			<string>PSListItemsController</string>
+			<key>defaults</key>
+			<string>com.apple.springboard</string>
+			<key>id</key>
+			<string>STAGE_MANAGER_SIDE</string>
+			<key>key</key>
+			<string>TPStageManagerSide</string>
+			<key>label</key>
+			<string>Stage Manager Side</string>
+			<key>validTitles</key>
+			<array>
+				<string>Left</string>
+				<string>Right</string>
+			</array>
+			<key>validValues</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
 			</array>
 		</dict>
 		<dict>

--- a/TrollPadPrefs/Resources/Root.plist
+++ b/TrollPadPrefs/Resources/Root.plist
@@ -7,8 +7,36 @@
 		<dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>
+			<key>footerText</key>
+			<string>Follow Control Center preserves the current behavior. Stage Manager also unlocks main-display window resizing. Respring after changing modes.</string>
 			<key>label</key>
-			<string>Stage Manager</string>
+			<string>Multitasking</string>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSLinkListCell</string>
+			<key>default</key>
+			<integer>0</integer>
+			<key>detail</key>
+			<string>PSListItemsController</string>
+			<key>defaults</key>
+			<string>com.apple.springboard</string>
+			<key>key</key>
+			<string>TPMultitaskingMode</string>
+			<key>label</key>
+			<string>Multitasking Mode</string>
+			<key>validTitles</key>
+			<array>
+				<string>Follow Control Center</string>
+				<string>Off</string>
+				<string>Stage Manager</string>
+			</array>
+			<key>validValues</key>
+			<array>
+				<integer>0</integer>
+				<integer>1</integer>
+				<integer>3</integer>
+			</array>
 		</dict>
 		<dict>
 			<key>cell</key>
@@ -79,8 +107,26 @@
 		<dict>
 			<key>cell</key>
 			<string>PSGroupCell</string>
+			<key>footerText</key>
+			<string>Disable the iPadOS keyboard to restore iPhone layouts, including Chinese 9-Key.</string>
 			<key>label</key>
-			<string>Miscellaneous</string>
+			<string>Keyboard</string>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSSwitchCell</string>
+			<key>default</key>
+			<true/>
+			<key>defaults</key>
+			<string>com.kdt.trollpad</string>
+			<key>id</key>
+			<string>ENABLE_IPAD_KEYBOARD</string>
+			<key>key</key>
+			<string>TPEnableiPadKeyboard</string>
+			<key>label</key>
+			<string>Enable iPadOS Keyboard</string>
+			<key>PostNotification</key>
+			<string>com.kdt.trollpad/saved</string>
 		</dict>
 		<dict>
 			<key>cell</key>
@@ -89,10 +135,20 @@
 			<false/>
 			<key>defaults</key>
 			<string>com.kdt.trollpad</string>
+			<key>id</key>
+			<string>SHOW_SHORTCUT_BUTTONS</string>
 			<key>key</key>
 			<string>TPShowShortcutButtonsOnKeyboard</string>
 			<key>label</key>
 			<string>Show shortcut buttons on keyboard</string>
+			<key>PostNotification</key>
+			<string>com.kdt.trollpad/saved</string>
+		</dict>
+		<dict>
+			<key>cell</key>
+			<string>PSGroupCell</string>
+			<key>label</key>
+			<string>Miscellaneous</string>
 		</dict>
 		<dict>
 			<key>cell</key>

--- a/TrollPadPrefs/TPPRootListController.m
+++ b/TrollPadPrefs/TPPRootListController.m
@@ -4,14 +4,33 @@
 
 #define PREF_PATH @"/var/mobile/Library/Preferences/com.kdt.trollpad.plist"
 
+static NSString *const TPEnableiPadKeyboardKey = @"TPEnableiPadKeyboard";
+static NSString *const TPEnableiPadKeyboardSpecifierID = @"ENABLE_IPAD_KEYBOARD";
+static NSString *const TPShowShortcutButtonsSpecifierID = @"SHOW_SHORTCUT_BUTTONS";
+
 @implementation TPPRootListController
 
 - (NSArray *)specifiers {
     if (!_specifiers) {
         _specifiers = [self loadSpecifiersFromPlistName:@"Root" target:self];
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:@"Respring" style:UIBarButtonItemStylePlain target:self action:@selector(respring)];
+
+        PSSpecifier *enableiPadKeyboardSpecifier = [self specifierForID:TPEnableiPadKeyboardSpecifierID];
+        PSSpecifier *shortcutButtonsSpecifier = [self specifierForID:TPShowShortcutButtonsSpecifierID];
+        BOOL enableiPadKeyboard = [[self readPreferenceValue:enableiPadKeyboardSpecifier] boolValue];
+        [shortcutButtonsSpecifier setProperty:@(enableiPadKeyboard) forKey:PSEnabledKey];
     }
     return _specifiers;
+}
+
+- (void)setPreferenceValue:(id)value specifier:(PSSpecifier *)specifier {
+    [super setPreferenceValue:value specifier:specifier];
+
+    if ([[specifier propertyForKey:PSKeyNameKey] isEqualToString:TPEnableiPadKeyboardKey]) {
+        PSSpecifier *shortcutButtonsSpecifier = [self specifierForID:TPShowShortcutButtonsSpecifierID];
+        [shortcutButtonsSpecifier setProperty:@([value boolValue]) forKey:PSEnabledKey];
+        [self reloadSpecifier:shortcutButtonsSpecifier animated:YES];
+    }
 }
 
 - (void)openDisplayArrangement {

--- a/TrollPadPrefs/TPPRootListController.m
+++ b/TrollPadPrefs/TPPRootListController.m
@@ -7,6 +7,10 @@
 static NSString *const TPEnableiPadKeyboardKey = @"TPEnableiPadKeyboard";
 static NSString *const TPEnableiPadKeyboardSpecifierID = @"ENABLE_IPAD_KEYBOARD";
 static NSString *const TPShowShortcutButtonsSpecifierID = @"SHOW_SHORTCUT_BUTTONS";
+static NSString *const TPMultitaskingModeKey = @"TPMultitaskingMode";
+static NSString *const TPMultitaskingModeSpecifierID = @"MULTITASKING_MODE";
+static NSString *const TPStageManagerSideSpecifierID = @"STAGE_MANAGER_SIDE";
+static NSInteger const TPMultitaskingModeStageManager = 3;
 
 @implementation TPPRootListController
 
@@ -19,6 +23,11 @@ static NSString *const TPShowShortcutButtonsSpecifierID = @"SHOW_SHORTCUT_BUTTON
         PSSpecifier *shortcutButtonsSpecifier = [self specifierForID:TPShowShortcutButtonsSpecifierID];
         BOOL enableiPadKeyboard = [[self readPreferenceValue:enableiPadKeyboardSpecifier] boolValue];
         [shortcutButtonsSpecifier setProperty:@(enableiPadKeyboard) forKey:PSEnabledKey];
+
+        PSSpecifier *multitaskingModeSpecifier = [self specifierForID:TPMultitaskingModeSpecifierID];
+        PSSpecifier *stageManagerSideSpecifier = [self specifierForID:TPStageManagerSideSpecifierID];
+        NSInteger multitaskingMode = [[self readPreferenceValue:multitaskingModeSpecifier] integerValue];
+        [stageManagerSideSpecifier setProperty:@(multitaskingMode == TPMultitaskingModeStageManager) forKey:PSEnabledKey];
     }
     return _specifiers;
 }
@@ -30,6 +39,12 @@ static NSString *const TPShowShortcutButtonsSpecifierID = @"SHOW_SHORTCUT_BUTTON
         PSSpecifier *shortcutButtonsSpecifier = [self specifierForID:TPShowShortcutButtonsSpecifierID];
         [shortcutButtonsSpecifier setProperty:@([value boolValue]) forKey:PSEnabledKey];
         [self reloadSpecifier:shortcutButtonsSpecifier animated:YES];
+    }
+
+    if ([[specifier propertyForKey:PSKeyNameKey] isEqualToString:TPMultitaskingModeKey]) {
+        PSSpecifier *stageManagerSideSpecifier = [self specifierForID:TPStageManagerSideSpecifierID];
+        [stageManagerSideSpecifier setProperty:@([value integerValue] == TPMultitaskingModeStageManager) forKey:PSEnabledKey];
+        [self reloadSpecifier:stageManagerSideSpecifier animated:YES];
     }
 }
 

--- a/TweakSB.x
+++ b/TweakSB.x
@@ -26,6 +26,16 @@ typedef NS_ENUM(NSInteger, TPMultitaskingMode) {
     TPMultitaskingModeStageManager = 3,
 };
 
+typedef NS_ENUM(NSInteger, TPStageManagerSide) {
+    TPStageManagerSideLeft = 0,
+    TPStageManagerSideRight = 1,
+};
+
+typedef struct {
+    double leadingAlpha;
+    double trailingAlpha;
+} TPSwitcherGradientWallpaperAttributes;
+
 static BOOL isMultitaskingModeOff() {
     return pref.multitaskingMode == TPMultitaskingModeOff;
 }
@@ -33,6 +43,27 @@ static BOOL isMultitaskingModeOff() {
 static BOOL isStageManagerMode() {
     return pref.multitaskingMode == TPMultitaskingModeStageManager;
 }
+
+static BOOL shouldUseRightStageManagerSide() {
+    return isStageManagerMode() && pref.stageManagerSide == TPStageManagerSideRight;
+}
+
+static BOOL isContinuousExposeObject(id object) {
+    return [NSStringFromClass(object_getClass(object)) containsString:@"ContinuousExpose"];
+}
+
+static __thread NSUInteger forceStageManagerRightToLeft = 0;
+
+#define TPBeginStageManagerRightToLeft() \
+    BOOL tpShouldForceStageManagerRightToLeft = shouldUseRightStageManagerSide() && isContinuousExposeObject(self); \
+    if (tpShouldForceStageManagerRightToLeft) { \
+        forceStageManagerRightToLeft++; \
+    }
+
+#define TPEndStageManagerRightToLeft() \
+    if (tpShouldForceStageManagerRightToLeft) { \
+        forceStageManagerRightToLeft--; \
+    }
 
 static BOOL canInstallStageManagerSwitcherHook() {
     Class switcherControllerClass = objc_getClass("SBSwitcherController");
@@ -52,6 +83,21 @@ static BOOL canInstallStageManagerCapabilityHooks() {
         class_getInstanceMethod(applicationClass, @selector(supportsChamoisSceneResizing)) &&
         class_getInstanceMethod(applicationClass, @selector(supportsChamoisViewResizing)) &&
         class_getInstanceMethod(applicationClass, @selector(alwaysMaximizedInChamois));
+}
+
+static BOOL canInstallStageManagerSideHooks() {
+    Class switcherModifierClass = objc_getClass("SBSwitcherModifier");
+    Class stripModifierClass = objc_getClass("SBStripContinuousExposeSwitcherModifier");
+
+    if (switcherModifierClass) {
+        (void)[(id)switcherModifierClass class];
+    }
+
+    return switcherModifierClass &&
+        class_getInstanceMethod(switcherModifierClass, @selector(isRTLEnabled)) &&
+        stripModifierClass &&
+        class_getInstanceMethod(stripModifierClass, @selector(_appStripOriginX)) &&
+        class_getInstanceMethod(UIApplication.class, @selector(userInterfaceLayoutDirection));
 }
 
 // Since some methods explicitly check for user interface idiom, I have no better way to fool them
@@ -319,6 +365,10 @@ static uint16_t forcePadIdiom = 0;
 %end
 
 %hook UIApplication
+- (UIUserInterfaceLayoutDirection)userInterfaceLayoutDirection {
+    return forceStageManagerRightToLeft > 0 ? UIUserInterfaceLayoutDirectionRightToLeft : %orig;
+}
+
 - (id)_defaultSupportedInterfaceOrientations {
     forcePadIdiom++;
     id result = %orig;
@@ -409,6 +459,192 @@ static uint16_t forcePadIdiom = 0;
 
 - (BOOL)alwaysMaximizedInChamois {
     return isStageManagerMode() ? NO : %orig;
+}
+%end
+%end
+
+%group TPStageManagerSideHooks
+%hook SBSwitcherModifier
+- (BOOL)isRTLEnabled {
+    if (shouldUseRightStageManagerSide() && isContinuousExposeObject(self)) {
+        return YES;
+    }
+    return %orig;
+}
+
+- (CGRect)scaledFrameForLayoutRole:(NSInteger)layoutRole inAppLayout:(id)appLayout atIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBFluidSwitcherGestureManager
+- (NSUInteger)_continuousExposeStripEdge {
+    return shouldUseRightStageManagerSide() ? UIRectEdgeRight : %orig;
+}
+%end
+
+%hook SBContinuousExposeAutoLayoutController
+- (id)spaceByPerformingAutoLayoutWithSpace:(id)space previousSpace:(id)previousSpace configuration:(id)configuration options:(NSUInteger)options {
+    TPBeginStageManagerRightToLeft();
+    id result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBContinuousExposeAppToInlineAppExposeSwitcherModifier
+- (CGRect)frameForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBContinuousExposeFullScreenCrossblurTransitionSwitcherModifier
+- (CGPoint)anchorPointForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGPoint result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)perspectiveAngleForAppLayout:(id)appLayout {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBContinuousExposeHomeGestureSwitcherModifier
+- (void)_updateTranslationAdjustmentForGestureFromHomeScreenIfNeededWithEvent:(id)event {
+    TPBeginStageManagerRightToLeft();
+    %orig;
+    TPEndStageManagerRightToLeft();
+}
+
+- (CGRect)frameForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)perspectiveAngleForAppLayout:(id)appLayout {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)_rangeForPerspectiveAngleProgressOfAppLayout:(id)appLayout outMin:(double)minimum outMax:(double)maximum {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)_maxPerspectiveAngleForSelectedAppLayout {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBFullScreenContinuousExposeSwitcherModifier
+- (unsigned int)_continuousExposeStripEdge {
+    TPBeginStageManagerRightToLeft();
+    unsigned int result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBInlineAppExposeContinuousExposeSwitcherModifier
+- (CGRect)frameForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (CGRect)frameForLayoutRole:(NSInteger)layoutRole inAppLayout:(id)appLayout withBounds:(CGRect)bounds {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (CGRect)_inlineAppExposeSwitcherFrame {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBRevealContinuousExposeStripOverflowGestureModifier
+- (CGRect)frameForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+%end
+
+%hook SBStripContinuousExposeSwitcherModifier
+- (CGPoint)anchorPointForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    CGPoint result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (CGPoint)adjustedSpaceAccessoryViewAnchorPoint:(CGPoint)anchorPoint forAppLayout:(id)appLayout {
+    TPBeginStageManagerRightToLeft();
+    CGPoint result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (TPSwitcherGradientWallpaperAttributes)wallpaperGradientAttributesForIndex:(NSUInteger)index {
+    TPBeginStageManagerRightToLeft();
+    TPSwitcherGradientWallpaperAttributes result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)perspectiveAngleForAppLayout:(id)appLayout {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (double)_appStripOriginX {
+    TPBeginStageManagerRightToLeft();
+    double result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (CGRect)_stripFrame {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
+}
+
+- (CGRect)_cachedOrFallbackFrameForIndex:(NSUInteger)index cacheValidityToken:(id)token {
+    TPBeginStageManagerRightToLeft();
+    CGRect result = %orig;
+    TPEndStageManagerRightToLeft();
+    return result;
 }
 %end
 %end
@@ -548,6 +784,9 @@ static BOOL shouldForceMultitaskingProperty(CFStringRef property) {
     }
     if (canInstallStageManagerCapabilityHooks()) {
         %init(TPStageManagerCapabilityHooks);
+    }
+    if (canInstallStageManagerSideHooks()) {
+        %init(TPStageManagerSideHooks);
     }
 
     // Unlock external display support for MDC versions

--- a/TweakSB.x
+++ b/TweakSB.x
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <MobileGestalt/MobileGestalt.h>
 #import <objc/runtime.h>
 #import "SpringBoard.h"
 #import "TPPrefsObserver.h"
@@ -18,6 +19,40 @@
 #endif
 
 static TPPrefsObserver* pref;
+
+typedef NS_ENUM(NSInteger, TPMultitaskingMode) {
+    TPMultitaskingModeFollowControlCenter = 0,
+    TPMultitaskingModeOff = 1,
+    TPMultitaskingModeStageManager = 3,
+};
+
+static BOOL isMultitaskingModeOff() {
+    return pref.multitaskingMode == TPMultitaskingModeOff;
+}
+
+static BOOL isStageManagerMode() {
+    return pref.multitaskingMode == TPMultitaskingModeStageManager;
+}
+
+static BOOL canInstallStageManagerSwitcherHook() {
+    Class switcherControllerClass = objc_getClass("SBSwitcherController");
+
+    return switcherControllerClass &&
+        class_getInstanceMethod(switcherControllerClass, @selector(windowManagementStyle));
+}
+
+static BOOL canInstallStageManagerCapabilityHooks() {
+    Class appSwitcherDefaultsClass = objc_getClass("SBAppSwitcherDefaults");
+    Class applicationClass = objc_getClass("SBApplication");
+
+    return appSwitcherDefaultsClass &&
+        class_getInstanceMethod(appSwitcherDefaultsClass, @selector(medusaMultitaskingEnabled)) &&
+        class_getInstanceMethod(appSwitcherDefaultsClass, @selector(chamoisWindowingEnabled)) &&
+        applicationClass &&
+        class_getInstanceMethod(applicationClass, @selector(supportsChamoisSceneResizing)) &&
+        class_getInstanceMethod(applicationClass, @selector(supportsChamoisViewResizing)) &&
+        class_getInstanceMethod(applicationClass, @selector(alwaysMaximizedInChamois));
+}
 
 // Since some methods explicitly check for user interface idiom, I have no better way to fool them
 // so I just hook them, set iPad idiom when necessary and set back to iPhone after calling original
@@ -151,6 +186,22 @@ static uint16_t forcePadIdiom = 0;
 }
 %end
 
+%group TPStageManagerSwitcherHook
+%hook SBSwitcherController
+- (NSUInteger)windowManagementStyle {
+    switch (pref.multitaskingMode) {
+        case TPMultitaskingModeOff:
+            return 0;
+        case TPMultitaskingModeStageManager:
+            return 2;
+        case TPMultitaskingModeFollowControlCenter:
+        default:
+            return %orig;
+    }
+}
+%end
+%end
+
 // Min width and height are 150, smaller may crash the app
 %hook SBSwitcherChamoisLayoutAttributes
 - (void)setGridWidths:(NSArray<NSNumber *> *)values {
@@ -227,7 +278,7 @@ static uint16_t forcePadIdiom = 0;
 %hook SBFluidSwitcherItemContainer
 - (void)setAllowedTouchResizeCorners:(NSUInteger)cornerMask {
     // !self.isResizingAllowed && 
-    if (self._screen != UIScreen.mainScreen) {
+    if (self._screen != UIScreen.mainScreen || isStageManagerMode()) {
         %orig(0b1111);
         // 1100: enable resizing for bottoms
         // 1111: enable resizing for all corners
@@ -306,7 +357,7 @@ static uint16_t forcePadIdiom = 0;
 
 %hook SBMedusaConfigurationUsageMetric
 - (BOOL)_isFloatingActive {
-    return YES;
+    return isMultitaskingModeOff() ? %orig : YES;
 }
 %end
 
@@ -316,13 +367,56 @@ static uint16_t forcePadIdiom = 0;
 }
 
 - (NSInteger)medusaCapabilities {
-    return 2;
+    return isMultitaskingModeOff() ? %orig : 2;
+}
+%end
+
+%group TPStageManagerCapabilityHooks
+%hook SBAppSwitcherDefaults
+- (BOOL)medusaMultitaskingEnabled {
+    switch (pref.multitaskingMode) {
+        case TPMultitaskingModeOff:
+            return NO;
+        case TPMultitaskingModeStageManager:
+            return YES;
+        case TPMultitaskingModeFollowControlCenter:
+        default:
+            return %orig;
+    }
+}
+
+- (BOOL)chamoisWindowingEnabled {
+    switch (pref.multitaskingMode) {
+        case TPMultitaskingModeOff:
+            return NO;
+        case TPMultitaskingModeStageManager:
+            return YES;
+        case TPMultitaskingModeFollowControlCenter:
+        default:
+            return %orig;
+    }
 }
 %end
 
 %hook SBApplication
+- (BOOL)supportsChamoisSceneResizing {
+    return isStageManagerMode() ? YES : %orig;
+}
+
+- (BOOL)supportsChamoisViewResizing {
+    return isStageManagerMode() ? YES : %orig;
+}
+
+- (BOOL)alwaysMaximizedInChamois {
+    return isStageManagerMode() ? NO : %orig;
+}
+%end
+%end
+
+%hook SBApplication
 - (BOOL)isMedusaCapable {
-    return pref.forceEnableMedusaForLandscapeOnlyApps ||
+    return isMultitaskingModeOff() ? %orig :
+        pref.forceEnableMedusaForLandscapeOnlyApps ||
         (self.info.supportedInterfaceOrientations & UIInterfaceOrientationMaskPortrait) != 0;
 }
 
@@ -333,7 +427,7 @@ static uint16_t forcePadIdiom = 0;
 
 %hook SBMainWorkspace
 - (BOOL)isMedusaEnabled {
-    return YES;
+    return isMultitaskingModeOff() ? %orig : YES;
 }
 %end
 
@@ -387,16 +481,75 @@ int hookedExtDisplayEnabledFunc() {
 }
 %end
 
-BOOL MGGetBoolAnswer(NSString* property);
-%hookf(BOOL, MGGetBoolAnswer, NSString* property) {
-    // Hook ipad, DeviceSupportsEnhancedMultitasking
-    if ([property isEqualToString:@"DeviceSupportsEnhancedMultitasking"]) {
-        return YES;
+static BOOL isEnhancedMultitaskingProperty(CFStringRef property) {
+    if (!property) {
+        return NO;
+    }
+
+    return CFEqual(property, CFSTR("DeviceSupportsEnhancedMultitasking")) ||
+        CFEqual(property, CFSTR("qeaj75wk3HF4DwQ8qbIi7g")) ||
+        CFEqual(property, CFSTR("DeviceSupportsSingleDisplayEnhancedMultitasking")) ||
+        CFEqual(property, CFSTR("fbpzGGoBNcvDLt4LlZGnfA"));
+}
+
+static BOOL isMedusaCapabilityProperty(CFStringRef property) {
+    if (!property) {
+        return NO;
+    }
+
+    // These are the four MobileGestalt capabilities required for iPadOS
+    // windowing. Do not spoof the iPad bit or DeviceClassNumber here: those also
+    // change unrelated phone UI such as the status bar and keyboard.
+    return CFEqual(property, CFSTR("MedusaFloatingLiveAppCapability")) ||
+        CFEqual(property, CFSTR("mG0AnH/Vy1veoqoLRAIgTA")) ||
+        CFEqual(property, CFSTR("MedusaOverlayAppCapability")) ||
+        CFEqual(property, CFSTR("UCG5MkVahJxG1YULbbd5Bg")) ||
+        CFEqual(property, CFSTR("MedusaPinnedAppCapability")) ||
+        CFEqual(property, CFSTR("ZYqko/XM5zD3XBfN5RmaXA")) ||
+        CFEqual(property, CFSTR("MedusaPIPCapability")) ||
+        CFEqual(property, CFSTR("nVh/gwNpy7Jv1NOk00CMrw"));
+}
+
+static BOOL shouldForceMultitaskingProperty(CFStringRef property) {
+    return (isEnhancedMultitaskingProperty(property) && !isMultitaskingModeOff()) ||
+        (isMedusaCapabilityProperty(property) && isStageManagerMode());
+}
+
+%hookf(bool, MGGetBoolAnswer, CFStringRef property) {
+    if (shouldForceMultitaskingProperty(property)) {
+        return true;
+    }
+    return %orig;
+}
+
+%hookf(CFTypeRef, MGCopyAnswer, CFStringRef property, CFDictionaryRef options) {
+    if (shouldForceMultitaskingProperty(property)) {
+        return CFRetain(kCFBooleanTrue);
+    }
+    return %orig;
+}
+
+%hookf(CFTypeRef, MGCopyAnswerWithError, CFStringRef property, CFDictionaryRef options, int *error) {
+    if (shouldForceMultitaskingProperty(property)) {
+        if (error) {
+            *error = 0;
+        }
+        return CFRetain(kCFBooleanTrue);
     }
     return %orig;
 }
 
 %ctor {
+    pref = [TPPrefsObserver new];
+    %init;
+
+    if (canInstallStageManagerSwitcherHook()) {
+        %init(TPStageManagerSwitcherHook);
+    }
+    if (canInstallStageManagerCapabilityHooks()) {
+        %init(TPStageManagerCapabilityHooks);
+    }
+
     // Unlock external display support for MDC versions
     void *sbFoundationHandle = dlopen("/System/Library/PrivateFrameworks/SpringBoardFoundation.framework/SpringBoardFoundation", RTLD_GLOBAL);
     // iOS 16.0
@@ -409,5 +562,4 @@ BOOL MGGetBoolAnswer(NSString* property);
         MSHookFunction((void *)extDisplayEnabledFunc, (void *)hookedExtDisplayEnabledFunc, NULL);
     }
 
-    pref = [TPPrefsObserver new];
 }

--- a/TweakUI.x
+++ b/TweakUI.x
@@ -1,11 +1,13 @@
 #import "UIKitPrivate.h"
-#import <rootless.h>
 
-static BOOL forcePadKBIdiom = YES, showShortcutButtonsOnKeyboard;
+static BOOL enableiPadKeyboard = YES, forcePadKBIdiom = YES, showShortcutButtonsOnKeyboard;
 
 // Unlock iPadOS keyboard
 UIUserInterfaceIdiom UIKeyboardGetSafeDeviceIdiom();
 %hookf(UIUserInterfaceIdiom, UIKeyboardGetSafeDeviceIdiom) {
+    if (!enableiPadKeyboard) {
+        return UIUserInterfaceIdiomPhone;
+    }
     return forcePadKBIdiom ? UIUserInterfaceIdiomPad : %orig;
 }
 
@@ -82,11 +84,23 @@ UIUserInterfaceIdiom UIKeyboardGetSafeDeviceIdiom();
 %end
 
 static void loadPrefs() {
-	NSMutableDictionary *settings = [[NSMutableDictionary alloc] initWithContentsOfFile:@(ROOT_PATH("/var/mobile/Library/Preferences/com.kdt.trollpad.plist"))];
-	showShortcutButtonsOnKeyboard = [[settings objectForKey:@"TPShowShortcutButtonsOnKeyboard"] boolValue];
+    CFStringRef appID = CFSTR("com.kdt.trollpad");
+    Boolean keyExists = false;
+
+    CFPreferencesAppSynchronize(appID);
+    enableiPadKeyboard = CFPreferencesGetAppBooleanValue(CFSTR("TPEnableiPadKeyboard"), appID, &keyExists);
+    if (!keyExists) {
+        enableiPadKeyboard = YES;
+    }
+    showShortcutButtonsOnKeyboard = enableiPadKeyboard &&
+        CFPreferencesGetAppBooleanValue(CFSTR("TPShowShortcutButtonsOnKeyboard"), appID, NULL);
+}
+
+static void prefsChanged(CFNotificationCenterRef center, void *observer, CFStringRef name, const void *object, CFDictionaryRef userInfo) {
+    loadPrefs();
 }
 
 %ctor {
     loadPrefs();
-    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, (CFNotificationCallback)loadPrefs, CFSTR("com.kdt.trollpad/saved"), NULL, CFNotificationSuspensionBehaviorCoalesce);
+    CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, prefsChanged, CFSTR("com.kdt.trollpad/saved"), NULL, CFNotificationSuspensionBehaviorCoalesce);
 }

--- a/layout/DEBIAN/postinst
+++ b/layout/DEBIAN/postinst
@@ -1,21 +1,33 @@
 #!/bin/sh
 
 set -e
-jb_root_path=$(realpath $HOME/../..)
+
+jb_root_path=$(realpath "$HOME/../..")
+
 bundle_system=/System/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle
-bundle_jb=$jb_root_path/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle
-plistbuddy=$jb_root_path/usr/libexec/PlistBuddy
+if [ -d /rootfs/System/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle ]; then
+	bundle_system=/rootfs/System/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle
+fi
+bundle_jb="$jb_root_path/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle"
+bundle_info="$bundle_jb/Info.plist"
+plistbuddy="$jb_root_path/usr/libexec/PlistBuddy"
 
 case "$1" in
 	(configure)
-	if [ -d $bundle_system ] ; then
-		# Copy Stage Manager CC module
-		ln -sf $bundle_system/* $bundle_jb/
-		rm $bundle_jb/Info.plist
-		cp $bundle_system/Info.plist $bundle_jb/Info.plist
-		$plistbuddy -c "Delete :SBIconVisibilityDefaultVisible" $bundle_jb/Info.plist
-		$plistbuddy -c "Delete :SBIconVisibilitySetByAppPreference" $bundle_jb/Info.plist
-		$plistbuddy -c "Add :UIDeviceFamily:0 integer 1" $bundle_jb/Info.plist
+	if [ -d "$bundle_system" ] && [ -x "$plistbuddy" ]; then
+		mkdir -p "$bundle_jb"
+		ln -sf "$bundle_system"/* "$bundle_jb/"
+		rm -f "$bundle_info"
+		cp "$bundle_system/Info.plist" "$bundle_info"
+
+		# These keys are not present on every iOS version.
+		"$plistbuddy" -c "Delete :SBIconVisibilityDefaultVisible" "$bundle_info" >/dev/null 2>&1 || :
+		"$plistbuddy" -c "Delete :SBIconVisibilitySetByAppPreference" "$bundle_info" >/dev/null 2>&1 || :
+		"$plistbuddy" -c "Delete :UIDeviceFamily" "$bundle_info" >/dev/null 2>&1 || :
+		"$plistbuddy" -c "Add :UIDeviceFamily array" "$bundle_info"
+		"$plistbuddy" -c "Add :UIDeviceFamily:0 integer 1" "$bundle_info"
+	else
+		echo "TrollPad: Stage Manager Control Center module unavailable; skipping installation" >&2
 	fi
 	;;
 	(abort-upgrade|abort-remove|abort-deconfigure)

--- a/layout/DEBIAN/postrm
+++ b/layout/DEBIAN/postrm
@@ -1,12 +1,13 @@
 #!/bin/sh
 
 set -e
-jb_root_path=$(realpath $HOME/../..)
-bundle_jb=$jb_root_path/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle
+
+jb_root_path=$(realpath "$HOME/../..")
+bundle_jb="$jb_root_path/Library/ControlCenter/Bundles/ContinuousExposeModule.bundle"
 
 case "$1" in
 	(remove)
-	rm -rf $bundle_jb
+	rm -rf "$bundle_jb"
 	;;
 esac
 


### PR DESCRIPTION
## Summary
- Add an Enable iPadOS Keyboard preference. Disabling it restores the iPhone keyboard layout, primarily for Chinese 9-Key input.
- Disable the dependent keyboard shortcut-buttons preference while the iPadOS keyboard is disabled.
- Add Follow Control Center, Off, and Stage Manager multitasking modes.
- Add a Stage Manager Side preference, available only in Stage Manager mode, to place the recent-app strip and its reveal gesture on the left or right.
- Scope the right-side layout override to Continuous Expose so the rest of SpringBoard keeps its normal layout direction.
- Enable the four MobileGestalt Medusa capabilities required for movable and resizable Stage Manager windows on the main display, without spoofing the iPad bit or DeviceClassNumber.
- Install version-specific SpringBoard hooks only when their classes and selectors are available.
- Support RootHide package builds and locate the stock ContinuousExpose Control Center module under /rootfs, skipping module installation gracefully when unavailable.

## Testing
- iPhone 13 Pro Max, iOS 17.3.1, RootHide, with CCSupport installed.
- Follow Control Center, Off, and Stage Manager modes verified.
- Stage Manager windows can be selected, moved, and resized.
- Left and Right Stage Manager sides verified. Right moves both the recent-app strip and its reveal gesture, leaving the left-edge swipe available for app navigation.
- Disabling the iPadOS keyboard restores Chinese 9-Key input and keeps the iPhone status bar style.
- Rootful, rootless, and RootHide packages build successfully with the iOS 16.5 SDK.